### PR TITLE
Module manager

### DIFF
--- a/.dfconfig
+++ b/.dfconfig
@@ -6,3 +6,9 @@
 # If empty, timestamp will not be displayed.
 # Example: "${YELLOW}[\D{%H:%M}]${RESET} "
 export DOTFILES_CONFIG_TIMESTAMP=""
+
+# DOTFILES_CONFIG_MODULES
+# array
+# Contains the listing of dotfile modules to install
+# A dotfile module listing is a url to a git repository containing a module.
+export DOTFILES_CONFIG_MODULES=()

--- a/.dfconfig
+++ b/.dfconfig
@@ -10,7 +10,7 @@ export DOTFILES_CONFIG_TIMESTAMP=""
 # DOTFILES_CONFIG_MODULES
 # array
 # Contains the listing of dotfile modules to install
-# A dotfile module listing is a url to a git repository containing a module.
+# A dotfile module listing is a url to a git repository containing a .dfmodule.
 export DOTFILES_CONFIG_MODULES=(
 	#"git@github.com:dersam/dotart.git"
 )

--- a/.dfconfig
+++ b/.dfconfig
@@ -14,3 +14,10 @@ export DOTFILES_CONFIG_TIMESTAMP=""
 export DOTFILES_CONFIG_MODULES=(
 	#"git@github.com:dersam/dotart.git"
 )
+
+# DOTFILES_CONFIG_DEV_MODULES
+# array
+# Contains a listing of modules to load from an absolute path. This allows
+# you to develop modules locally without having to push to a remote to see your
+# changes in action.
+export DOTFILES_CONFIG_DEV_MODULES=()

--- a/.dfconfig
+++ b/.dfconfig
@@ -11,4 +11,6 @@ export DOTFILES_CONFIG_TIMESTAMP=""
 # array
 # Contains the listing of dotfile modules to install
 # A dotfile module listing is a url to a git repository containing a module.
-export DOTFILES_CONFIG_MODULES=()
+export DOTFILES_CONFIG_MODULES=(
+	#"git@github.com:dersam/dotart.git"
+)

--- a/.dfmodules
+++ b/.dfmodules
@@ -8,6 +8,10 @@ if [ ! -d ~/.dotfiles/.modules ]; then
 	mkdir ~/.dotfiles/.modules
 fi
 
+if [ ! -d ~/.dotfiles/.modulesconfig ]; then
+	mkdir ~/.dotfiles/.modulesconfig
+fi
+
 olddir=`pwd`
 
 echo "${BLUE}${BOLD}Processing modules...${RESET}"
@@ -24,10 +28,18 @@ for i in ${DOTFILES_CONFIG_MODULES[@]}; do
 		git clone ${i}
 	fi
 
+	if [ ! -f ~/.dotfiles/.modulesconfig/$modname ] && [ -f ~/.dotfiles/.modules/$modname/.dfconfig ]; then
+		echo "${GREEN}Publishing $modname config...${RESET}"
+		cp ~/.dotfiles/.modules/$modname/.dfconfig ~/.dotfiles/.modulesconfig/$modname
+	fi
+
 	if [ -f $modname/.dfmodule ]; then
 		echo "${GREEN}Loading $modname...${RESET}"
 		cd $modname
 		source .dfmodule
+		if [ -f ~/.dotfiles/.modulesconfig/$modname ]; then
+			source ~/.dotfiles/.modulesconfig/$modname
+		fi
 	fi
 done
 

--- a/.dfmodules
+++ b/.dfmodules
@@ -1,0 +1,9 @@
+
+# Stop processing modules if no module config available
+if [[ -z $DOTFILES_CONFIG_MODULES ]]; then
+	return
+fi
+
+for i in ${DOTFILES_CONFIG_MODULES[@]}; do
+	echo ${i}
+done

--- a/.dfmodules
+++ b/.dfmodules
@@ -1,6 +1,6 @@
 
 # Stop processing modules if no module config available
-if [[ -z $DOTFILES_CONFIG_MODULES ]]; then
+if [ -z $DOTFILES_CONFIG_MODULES ] && [ -z $DOTFILES_CONFIG_DEV_MODULES ]; then
 	return
 fi
 
@@ -40,6 +40,24 @@ for i in ${DOTFILES_CONFIG_MODULES[@]}; do
 		if [ -f ~/.dotfiles/.modulesconfig/$modname ]; then
 			source ~/.dotfiles/.modulesconfig/$modname
 		fi
+	fi
+done
+
+for i in ${DOTFILES_CONFIG_DEV_MODULES[@]}; do
+	cd $olddir
+	if [ -d ${i} ]; then
+		cd ${i}
+		echo "${GREEN}DEV MODULE:Attempting to load ${i}...${RESET}"
+		if [ -f ".dfmodule" ];then
+			source ".dfmodule"
+			if [ -f ".dfconfig" ]; then
+				source ".dfconfig"
+			fi
+		else
+			echo "${RED}Failed to load dev module: ${i}/.dfmodule not found${RESET}"
+		fi
+	else
+		echo "${RED}Failed to load dev module: invalid directory ${i}."
 	fi
 done
 

--- a/.dfmodules
+++ b/.dfmodules
@@ -36,10 +36,10 @@ for i in ${DOTFILES_CONFIG_MODULES[@]}; do
 	if [ -f $modname/.dfmodule ]; then
 		echo "${GREEN}Loading $modname...${RESET}"
 		cd $modname
-		source .dfmodule
 		if [ -f ~/.dotfiles/.modulesconfig/$modname ]; then
 			source ~/.dotfiles/.modulesconfig/$modname
 		fi
+		source .dfmodule
 	fi
 done
 
@@ -48,13 +48,13 @@ for i in ${DOTFILES_CONFIG_DEV_MODULES[@]}; do
 	if [ -d ${i} ]; then
 		cd ${i}
 		echo "${GREEN}DEV MODULE:Attempting to load ${i}...${RESET}"
-		if [ -f ".dfmodule" ];then
-			source ".dfmodule"
-			if [ -f ".dfconfig" ]; then
-				source ".dfconfig"
+		if [ -f ".dfconfig" ];then
+			source ".dfconfig"
+			if [ -f ".dfmodule" ]; then
+				source ".dfmodule"
+			else
+				echo "${RED}Failed to load dev module: ${i}/.dfmodule not found${RESET}"
 			fi
-		else
-			echo "${RED}Failed to load dev module: ${i}/.dfmodule not found${RESET}"
 		fi
 	else
 		echo "${RED}Failed to load dev module: invalid directory ${i}."

--- a/.dfmodules
+++ b/.dfmodules
@@ -74,6 +74,7 @@ dfmakemodule() {
 	git init
 	touch .dfmodule
 	touch .dfconfig
+	touch README.md
 	git add .
 	git commit -m "Inital commit from dfmakemodule."
 }

--- a/.dfmodules
+++ b/.dfmodules
@@ -4,6 +4,18 @@ if [[ -z $DOTFILES_CONFIG_MODULES ]]; then
 	return
 fi
 
+olddir=`pwd`
+
 for i in ${DOTFILES_CONFIG_MODULES[@]}; do
-	echo ${i}
+	cd ~/.dotfiles/.modules
+	modname=`echo ${i}|awk -F: '{ print $NF}'|awk -F/ '{ print $NF}'|awk -F. '{ print $1}'`
+	if [ -d $modname ]; then
+		echo "${GREEN}Checking for updates to module $modname...${RESET}"
+		cd $modname && git pull
+	else
+		echo "${GREEN}Installing module $modname...${RESET}"
+		git clone ${i}
+	fi
 done
+
+cd $olddir

--- a/.dfmodules
+++ b/.dfmodules
@@ -65,7 +65,7 @@ cd $olddir
 
 # Initalizes an empty module at the specified path
 # Parameters: path,
-makemodule() {
+dfmakemodule() {
 	if [ -z $1 ]; then
 		return
 	fi
@@ -75,5 +75,5 @@ makemodule() {
 	touch .dfmodule
 	touch .dfconfig
 	git add .
-	git commit -m "makemodule initial commit"
+	git commit -m "Inital commit from dfmakemodule."
 }

--- a/.dfmodules
+++ b/.dfmodules
@@ -4,17 +4,29 @@ if [[ -z $DOTFILES_CONFIG_MODULES ]]; then
 	return
 fi
 
+if [ ! -d ~/.dotfiles/.modules ]; then
+	mkdir ~/.dotfiles/.modules
+fi
+
 olddir=`pwd`
+
+echo "${BLUE}${BOLD}Processing modules...${RESET}"
 
 for i in ${DOTFILES_CONFIG_MODULES[@]}; do
 	cd ~/.dotfiles/.modules
 	modname=`echo ${i}|awk -F: '{ print $NF}'|awk -F/ '{ print $NF}'|awk -F. '{ print $1}'`
 	if [ -d $modname ]; then
-		echo "${GREEN}Checking for updates to module $modname...${RESET}"
+		echo "${GREEN}Checking for updates to $modname...${RESET}"
 		cd $modname && git pull
+		cd ..
 	else
-		echo "${GREEN}Installing module $modname...${RESET}"
+		echo "${GREEN}Downloading $modname...${RESET}"
 		git clone ${i}
+	fi
+
+	if [ -f $modname/.dfmodule ]; then
+		echo "${GREEN}Loading $modname...${RESET}"
+		source $modname/.dfmodule
 	fi
 done
 

--- a/.dfmodules
+++ b/.dfmodules
@@ -26,7 +26,8 @@ for i in ${DOTFILES_CONFIG_MODULES[@]}; do
 
 	if [ -f $modname/.dfmodule ]; then
 		echo "${GREEN}Loading $modname...${RESET}"
-		source $modname/.dfmodule
+		cd $modname
+		source .dfmodule
 	fi
 done
 

--- a/.dfmodules
+++ b/.dfmodules
@@ -62,3 +62,18 @@ for i in ${DOTFILES_CONFIG_DEV_MODULES[@]}; do
 done
 
 cd $olddir
+
+# Initalizes an empty module at the specified path
+# Parameters: path,
+makemodule() {
+	if [ -z $1 ]; then
+		return
+	fi
+	mkdir -p $1
+	cd $1
+	git init
+	touch .dfmodule
+	touch .dfconfig
+	git add .
+	git commit -m "makemodule initial commit"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ehthumbs.db
 
 # Modules directory
 .modules/
+.modulesconfig/
 
 ## For quick testing, create any directory with ~ in front of it,
 ## and it will be ignored.

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ ehthumbs.db
 .Spotlight-V100
 .Trashes
 
+# Modules directory
+.modules/
+
 ## For quick testing, create any directory with ~ in front of it,
 ## and it will be ignored.
 ~*/

--- a/.modules/.gitignore
+++ b/.modules/.gitignore
@@ -1,0 +1,3 @@
+*
+
+!.gitignore

--- a/.modules/.gitignore
+++ b/.modules/.gitignore
@@ -1,3 +1,0 @@
-*
-
-!.gitignore

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,6 +36,7 @@ ln -vsfn ~/.dotfiles/.sshmotd ~/
 rm -rf ~/.vim && ln -vsfn ~/.dotfiles/.vim ~/
 ln -vsfn ~/.dotfiles/.vimrc ~/
 ln -vsfn ~/.dotfiles/dotfiles.sh ~/
+ln -vsfn ~/.dotfiles/.dfmodules ~/
 rm -rf ~/.weechat && ln -vsfn ~/.dotfiles/.weechat ~/
 
 # Create user bin if it doesn't exist.
@@ -89,6 +90,9 @@ fi
 # Install packages from given package management
 source ~/.functions
 source ~/packages.sh
+
+# Install dfmodules
+source ~/.dfmodules
 
 # Update terminal
 echo -e "${BLUE}${BOLD}Updating terminal with new profile.${RESET}"


### PR DESCRIPTION
Basic dotfiles module manager.  Given a git repository in the config, will clone it to the .modules directory.  Once cloned (or pulled if already cloned), will source the `.dfconfig`, then source the `.dfmodule` file in the root of the module repository.

To install/update modules: just run `dotfiles`.  Modules are loaded near the end of bootstrap.sh. Modules will be loaded in the order they appear in the module listing config array.

Config files are published to `.moduleconfig`. They will not be overwritten- if you want to republish it, delete the file from `.moduleconfig` and run `dotfiles`\- the default config from the module will be published.

Default `.dfconfig` has no modules.  https://github.com/dersam/dotart is a repository with a functional `.dfmodule` file and module `.dfconfig`, as an example.

To create a new module for development, run `dfmakemodule new/module/path`. This will create a module with a blank `.dfmodule` and `.dfconfig`, initialized in a git repository.

Also includes a config variable to specify the local path to a module you're developing, so that each change doesn't require a push.
